### PR TITLE
Refactor error handling in Repository & Service layers

### DIFF
--- a/internal/error/wrappers.go
+++ b/internal/error/wrappers.go
@@ -17,5 +17,7 @@ var (
 	ErrUserAccountNotFound = New("USER_ACCOUNT_SV_USER_ACCOUNT_NOT_FOUND", "user account not found").WithCode(http.StatusNotFound)
 	ErrUserProfileNotFound = New("USER_ACCOUNT_SV_USER_PROFILE_NOT_FOUND", "user profile not found").WithCode(http.StatusNotFound)
 
-	ErrUserExists = New("USER_ACCOUNT_SV_USER_EXISTS", "user already exists").WithCode(http.StatusConflict)
+	ErrUserExists        = New("USER_ACCOUNT_SV_USER_EXISTS", "user already exists").WithCode(http.StatusConflict)
+	ErrUserAccountExists = New("USER_ACCOUNT_SV_USER_ACCOUNT_EXISTS", "user account already exists").WithCode(http.StatusConflict)
+	ErrUserProfileExists = New("USER_ACCOUNT_SV_USER_PROFILE_EXISTS", "user profile already exists").WithCode(http.StatusConflict)
 )

--- a/internal/repository/postgres/user_account_repository.go
+++ b/internal/repository/postgres/user_account_repository.go
@@ -7,13 +7,14 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
+
 	"event-calendar/internal/domain"
 	"event-calendar/internal/dto/dmodel"
 	errs "event-calendar/internal/error"
 	"event-calendar/internal/logger"
 	mapper "event-calendar/internal/mapper/user/dmodel"
 	"event-calendar/internal/repository"
-	"fmt"
 
 	"github.com/jmoiron/sqlx"
 )

--- a/internal/repository/postgres/user_account_repository.go
+++ b/internal/repository/postgres/user_account_repository.go
@@ -7,14 +7,13 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
-
 	"event-calendar/internal/domain"
 	"event-calendar/internal/dto/dmodel"
 	errs "event-calendar/internal/error"
 	"event-calendar/internal/logger"
 	mapper "event-calendar/internal/mapper/user/dmodel"
 	"event-calendar/internal/repository"
+	"fmt"
 
 	"github.com/jmoiron/sqlx"
 )
@@ -58,7 +57,7 @@ func (repo *UserAccountRepositoryPostgres) ListUserAccountsByUserID(ctx context.
 				WHERE user_id = $1`, userID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, errs.ErrUserAccountNotFound.WithInfo(fmt.Sprintf("repository.ListUserAccountsByUserID: user accoounts not found for userID=%d", userID))
+			return nil, errs.ErrUserAccountNotFound.WithInfo(fmt.Sprintf("repository.ListUserAccountsByUserID: user accounts not found for userID=%d", userID))
 		}
 		return nil, errs.ErrDB.WithInfo(fmt.Sprintf("repository.ListUserAccountsByUserID: %v", err))
 	}

--- a/internal/repository/postgres/user_profile_repository.go
+++ b/internal/repository/postgres/user_profile_repository.go
@@ -7,13 +7,14 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
+
 	"event-calendar/internal/domain"
 	"event-calendar/internal/dto/dmodel"
 	errs "event-calendar/internal/error"
 	"event-calendar/internal/logger"
 	mapper "event-calendar/internal/mapper/user/dmodel"
 	"event-calendar/internal/repository"
-	"fmt"
 
 	"github.com/jmoiron/sqlx"
 )

--- a/internal/repository/postgres/user_profile_repository.go
+++ b/internal/repository/postgres/user_profile_repository.go
@@ -57,7 +57,7 @@ func (repo *UserProfileRepositoryPostgres) GetUserProfilesCount(ctx context.Cont
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, nil
 		}
-		return 0, errs.ErrDB.WithInfo(err.Error())
+		return 0, errs.ErrDB.WithInfo(fmt.Sprintf("repository: %v", err))
 	}
 
 	return count, nil
@@ -74,7 +74,7 @@ func (repo *UserProfileRepositoryPostgres) GetUserProfileByID(ctx context.Contex
 		if errors.Is(err, sql.ErrNoRows) {
 			return domain.UserProfile{}, errs.ErrUserProfileNotFound.WithInfo(fmt.Sprintf("repository: user profile not found for ID=%d", ID))
 		}
-		return domain.UserProfile{}, errs.ErrDB.WithInfo(err.Error())
+		return domain.UserProfile{}, errs.ErrDB.WithInfo(fmt.Sprintf("repository: %v", err))
 	}
 	return mapper.ProfileDtoToProfile(userProfileDto), nil
 }
@@ -92,7 +92,7 @@ func (repo *UserProfileRepositoryPostgres) GetUserProfileByUserID(ctx context.Co
 			return domain.UserProfile{}, errs.ErrUserProfileNotFound.WithInfo(
 				fmt.Sprintf("repository: user profile not found for userID=%d", userID))
 		}
-		return domain.UserProfile{}, errs.ErrDB.WithInfo(err.Error())
+		return domain.UserProfile{}, errs.ErrDB.WithInfo(fmt.Sprintf("repository: %v", err))
 	}
 	return mapper.ProfileDtoToProfile(userProfileDto), nil
 }
@@ -110,7 +110,7 @@ func (repo *UserProfileRepositoryPostgres) GetUserProfileByFirebaseUUID(ctx cont
 			return domain.UserProfile{}, errs.ErrUserProfileNotFound.WithInfo(
 				fmt.Sprintf("repository: user profile not found for uid=%s", firebaseUUID))
 		}
-		return domain.UserProfile{}, errs.ErrDB.WithInfo(err.Error())
+		return domain.UserProfile{}, errs.ErrDB.WithInfo(fmt.Sprintf("repository: %v", err))
 	}
 	return mapper.ProfileDtoToProfile(userProfileDto), nil
 }
@@ -126,9 +126,9 @@ func (repo *UserProfileRepositoryPostgres) CreateUserProfile(ctx context.Context
 	).Scan(&userID)
 	if err != nil {
 		if len(err.Error()) > 50 && err.Error()[:50] == pqDuplicateErr {
-			return 0, errs.ErrUserProfileExists.WithInfo(err.Error())
+			return 0, errs.ErrUserProfileExists.WithInfo(fmt.Sprintf("repository: %v", err))
 		}
-		return 0, errs.ErrDB.WithInfo(err.Error())
+		return 0, errs.ErrDB.WithInfo(fmt.Sprintf("repository: %v", err))
 	}
 	return userID, nil
 }

--- a/internal/repository/postgres/user_profile_repository_test.go
+++ b/internal/repository/postgres/user_profile_repository_test.go
@@ -2,9 +2,8 @@ package postgres
 
 import (
 	"context"
-	"testing"
-
 	"event-calendar/internal/domain/test"
+	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/jmoiron/sqlx"
@@ -132,12 +131,12 @@ func TestGetUserProfileByUUID(t *testing.T) {
 		AddRow(expectedUserProfile.ID, expectedUserProfile.FirstName, expectedUserProfile.LastName, expectedUserProfile.UserID, expectedUserProfile.BusinessName, expectedUserProfile.ContactEmail, expectedUserProfile.Organization, expectedUserProfile.AvatarFileName, expectedUserProfile.Description)
 
 	mock.ExpectQuery(`(?i)SELECT \* FROM user LEFT JOIN user_profiles ON user.id = user_profiles.user_id WHERE user.firebase_uid = \$1`).
-		WithArgs(user.FirebaseUID).
+		WithArgs(user.FirebaseUUID).
 		WillReturnRows(rows)
 
 	// ACT
 	ctx := context.Background()
-	userProfile, err := repo.GetUserProfileByFirebaseUID(ctx, user.FirebaseUID)
+	userProfile, err := repo.GetUserProfileByFirebaseUUID(ctx, user.FirebaseUUID)
 
 	// Assertions
 	assert.NoError(t, err)

--- a/internal/repository/postgres/user_profile_repository_test.go
+++ b/internal/repository/postgres/user_profile_repository_test.go
@@ -2,8 +2,9 @@ package postgres
 
 import (
 	"context"
-	"event-calendar/internal/domain/test"
 	"testing"
+
+	"event-calendar/internal/domain/test"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/jmoiron/sqlx"

--- a/internal/repository/postgres/user_profile_repository_test.go
+++ b/internal/repository/postgres/user_profile_repository_test.go
@@ -130,7 +130,7 @@ func TestGetUserProfileByUUID(t *testing.T) {
 		[]string{"id", "first_name", "last_name", "user_id", "business_name", "contact_email", "organization", "avatar_file_name", "description"}).
 		AddRow(expectedUserProfile.ID, expectedUserProfile.FirstName, expectedUserProfile.LastName, expectedUserProfile.UserID, expectedUserProfile.BusinessName, expectedUserProfile.ContactEmail, expectedUserProfile.Organization, expectedUserProfile.AvatarFileName, expectedUserProfile.Description)
 
-	mock.ExpectQuery(`(?i)SELECT \* FROM user LEFT JOIN user_profiles ON user.id = user_profiles.user_id WHERE user.firebase_uid = \$1`).
+	mock.ExpectQuery(`(?i)SELECT \* FROM user LEFT JOIN user_profiles ON user.id = user_profiles.user_id WHERE user.firebase_uuid = \$1`).
 		WithArgs(user.FirebaseUUID).
 		WillReturnRows(rows)
 

--- a/internal/repository/postgres/user_repository.go
+++ b/internal/repository/postgres/user_repository.go
@@ -7,13 +7,14 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
+
 	"event-calendar/internal/domain"
 	"event-calendar/internal/dto/dmodel"
 	errs "event-calendar/internal/error"
 	"event-calendar/internal/logger"
 	mapper "event-calendar/internal/mapper/user/dmodel"
 	"event-calendar/internal/repository"
-	"fmt"
 
 	"github.com/jmoiron/sqlx"
 )

--- a/internal/repository/postgres/user_repository.go
+++ b/internal/repository/postgres/user_repository.go
@@ -7,13 +7,13 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-
 	"event-calendar/internal/domain"
 	"event-calendar/internal/dto/dmodel"
 	errs "event-calendar/internal/error"
 	"event-calendar/internal/logger"
 	mapper "event-calendar/internal/mapper/user/dmodel"
 	"event-calendar/internal/repository"
+	"fmt"
 
 	"github.com/jmoiron/sqlx"
 )
@@ -57,7 +57,7 @@ func (repo *UserRepositoryPostgres) GetUsersCount(ctx context.Context) (int64, e
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, nil
 		}
-		return 0, errs.ErrDB.WithInfo(err.Error())
+		return 0, errs.ErrDB.WithInfo(fmt.Sprintf("repository.GetUserByID: %v", err))
 	}
 
 	return count, nil
@@ -65,32 +65,34 @@ func (repo *UserRepositoryPostgres) GetUsersCount(ctx context.Context) (int64, e
 
 // GetUserByID retrieves a user by its unique ID.
 // Returns errs.ErrUserNotFound if no matching record exists.
-func (repo *UserRepositoryPostgres) GetUserByID(ctx context.Context, id int64) (obj domain.User, err error) {
+func (repo *UserRepositoryPostgres) GetUserByID(ctx context.Context, ID int64) (obj domain.User, err error) {
 	var userDto dmodel.User
 	err = sqlx.GetContext(ctx, repo.dbDriver, &userDto,
 		`SELECT * FROM users
-				WHERE id = $1`, id)
+				WHERE id = $1`, ID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return domain.User{}, errs.ErrUserNotFound.WithInfo(err.Error())
+			return domain.User{}, errs.ErrUserNotFound.WithInfo(
+				fmt.Sprintf("repository.GetUserByID: user not found for ID=%d", ID))
 		}
-		return domain.User{}, errs.ErrDB.WithInfo(err.Error())
+		return domain.User{}, errs.ErrDB.WithInfo(fmt.Sprintf("repository.GetUserByID: %v", err))
 	}
 	return mapper.UserDtoToUser(userDto), nil
 }
 
-// GetUserByFirebaseUID retrieves a user by its unique Firebase UID.
+// GetUserByFirebaseUUID retrieves a user by its unique Firebase UID.
 // Returns errs.ErrUserNotFound if no matching record exists.
-func (repo *UserRepositoryPostgres) GetUserByFirebaseUID(ctx context.Context, firebaseUID string) (obj domain.User, err error) {
+func (repo *UserRepositoryPostgres) GetUserByFirebaseUUID(ctx context.Context, firebaseUUID string) (obj domain.User, err error) {
 	var userDto dmodel.User
 	err = sqlx.GetContext(ctx, repo.dbDriver, &userDto,
 		`SELECT * FROM users
-				WHERE firebase_uid = $1`, firebaseUID)
+				WHERE firebase_uuid = $1`, firebaseUUID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return domain.User{}, errs.ErrUserNotFound.WithInfo(err.Error())
+			return domain.User{}, errs.ErrUserNotFound.WithInfo(
+				fmt.Sprintf("repository.GetUserByFirebaseUUID: user not found for UUID=%s", firebaseUUID))
 		}
-		return domain.User{}, errs.ErrDB.WithInfo(err.Error())
+		return domain.User{}, errs.ErrDB.WithInfo(fmt.Sprintf("repository.GetUserByFirebaseUUID: %v", err))
 	}
 	return mapper.UserDtoToUser(userDto), nil
 }
@@ -101,14 +103,12 @@ func (repo *UserRepositoryPostgres) GetUserByFirebaseUID(ctx context.Context, fi
 func (repo *UserRepositoryPostgres) CreateUser(ctx context.Context, user domain.User) (userID int64, err error) {
 	err = repo.dbDriver.QueryRowxContext(
 		ctx,
-		`INSERT INTO users (firebase_uid, description) VALUES ($1, $2) RETURNING id`,
-		user.FirebaseUID, user.Description,
+		`INSERT INTO users (firebase_uuid, description) VALUES ($1, $2) RETURNING id`,
+		user.FirebaseUUID, user.Description,
 	).Scan(&userID)
 	if err != nil {
-		if len(err.Error()) > 50 {
-			if err.Error()[:50] == pqDuplicateErr {
-				return 0, errs.ErrDBConstraint.WithInfo(err.Error())
-			}
+		if len(err.Error()) > 50 && err.Error()[:50] == pqDuplicateErr {
+			return 0, errs.ErrUserExists.WithInfo(err.Error())
 		}
 		return 0, err
 	}

--- a/internal/repository/postgres/user_repository.go
+++ b/internal/repository/postgres/user_repository.go
@@ -7,14 +7,13 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
-
 	"event-calendar/internal/domain"
 	"event-calendar/internal/dto/dmodel"
 	errs "event-calendar/internal/error"
 	"event-calendar/internal/logger"
 	mapper "event-calendar/internal/mapper/user/dmodel"
 	"event-calendar/internal/repository"
+	"fmt"
 
 	"github.com/jmoiron/sqlx"
 )
@@ -108,10 +107,12 @@ func (repo *UserRepositoryPostgres) CreateUser(ctx context.Context, user domain.
 		user.FirebaseUUID, user.Description,
 	).Scan(&userID)
 	if err != nil {
+		errorInfo := fmt.Sprintf("repository.CreateUser: %v", err)
+
 		if len(err.Error()) > 50 && err.Error()[:50] == pqDuplicateErr {
-			return 0, errs.ErrUserExists.WithInfo(err.Error())
+			return 0, errs.ErrUserExists.WithInfo(errorInfo)
 		}
-		return 0, err
+		return 0, errs.ErrDB.WithInfo(errorInfo)
 	}
 	return userID, nil
 }

--- a/internal/repository/postgres/user_repository_test.go
+++ b/internal/repository/postgres/user_repository_test.go
@@ -2,8 +2,9 @@ package postgres
 
 import (
 	"context"
-	"event-calendar/internal/domain/test"
 	"testing"
+
+	"event-calendar/internal/domain/test"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/jmoiron/sqlx"

--- a/internal/repository/postgres/user_repository_test.go
+++ b/internal/repository/postgres/user_repository_test.go
@@ -2,9 +2,8 @@ package postgres
 
 import (
 	"context"
-	"testing"
-
 	"event-calendar/internal/domain/test"
+	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/jmoiron/sqlx"
@@ -52,8 +51,8 @@ func TestGetUserByID(t *testing.T) {
 
 	// Mock the query
 	rows := sqlmock.NewRows(
-		[]string{"id", "firebase_uid", "description"}).
-		AddRow(expectedUser.ID, expectedUser.FirebaseUID, expectedUser.Description)
+		[]string{"id", "firebase_uuid", "description"}).
+		AddRow(expectedUser.ID, expectedUser.FirebaseUUID, expectedUser.Description)
 
 	mock.ExpectQuery(`(?i)SELECT \* FROM users WHERE id = \$1`).
 		WithArgs(expectedUser.ID).
@@ -86,16 +85,16 @@ func TestGetUserByUUID(t *testing.T) {
 
 	// Mock the query
 	rows := sqlmock.NewRows(
-		[]string{"id", "firebase_uid", "description"}).
-		AddRow(expectedUser.ID, expectedUser.FirebaseUID, expectedUser.Description)
+		[]string{"id", "firebase_uuid", "description"}).
+		AddRow(expectedUser.ID, expectedUser.FirebaseUUID, expectedUser.Description)
 
-	mock.ExpectQuery(`(?i)SELECT \* FROM users WHERE firebase_uid = \$1`).
-		WithArgs(expectedUser.FirebaseUID).
+	mock.ExpectQuery(`(?i)SELECT \* FROM users WHERE firebase_uuid = \$1`).
+		WithArgs(expectedUser.FirebaseUUID).
 		WillReturnRows(rows)
 
 	// ACT
 	ctx := context.Background()
-	user, err := repo.GetUserByFirebaseUID(ctx, expectedUser.FirebaseUID)
+	user, err := repo.GetUserByFirebaseUUID(ctx, expectedUser.FirebaseUUID)
 
 	// Assertions
 	assert.NoError(t, err)
@@ -121,8 +120,8 @@ func TestCreateUser(t *testing.T) {
 	// Define expected behavior for mock
 	rows := sqlmock.NewRows([]string{"id"}).AddRow(1)
 	mock.ExpectQuery(
-		`(?i)INSERT INTO users \(firebase_uid, description\) VALUES \(\$1, \$2\) RETURNING id`).
-		WithArgs(newUser.FirebaseUID, newUser.Description).
+		`(?i)INSERT INTO users \(firebase_uuid, description\) VALUES \(\$1, \$2\) RETURNING id`).
+		WithArgs(newUser.FirebaseUUID, newUser.Description).
 		WillReturnRows(rows) // Return ID = 1
 
 	// ACT

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -5,7 +5,6 @@ package repository
 
 import (
 	"context"
-
 	"event-calendar/internal/domain"
 
 	"github.com/jmoiron/sqlx"
@@ -22,8 +21,8 @@ type UserRepository interface {
 	WithTx[UserRepository]
 	CreateUser(ctx context.Context, user domain.User) (int64, error)
 	GetUsersCount(ctx context.Context) (int64, error)
-	GetUserByID(ctx context.Context, id int64) (domain.User, error)
-	GetUserByFirebaseUID(ctx context.Context, uuid string) (domain.User, error)
+	GetUserByID(ctx context.Context, ID int64) (domain.User, error)
+	GetUserByFirebaseUUID(ctx context.Context, uuid string) (domain.User, error)
 }
 
 // UserProfileRepository defines the contract for user profile persistence operations.
@@ -31,9 +30,9 @@ type UserProfileRepository interface {
 	WithTx[UserProfileRepository]
 	CreateUserProfile(ctx context.Context, user domain.UserProfile) (int64, error)
 	GetUserProfilesCount(ctx context.Context) (int64, error)
-	GetUserProfileByID(ctx context.Context, id int64) (user domain.UserProfile, err error)
+	GetUserProfileByID(ctx context.Context, ID int64) (user domain.UserProfile, err error)
 	GetUserProfileByUserID(ctx context.Context, userID int64) (user domain.UserProfile, err error)
-	GetUserProfileByFirebaseUID(ctx context.Context, firebaseUID string) (user domain.UserProfile, err error)
+	GetUserProfileByFirebaseUUID(ctx context.Context, firebaseUUID string) (user domain.UserProfile, err error)
 }
 
 // UserAccountRepository defines the contract for user account persistence operations.

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -5,6 +5,7 @@ package repository
 
 import (
 	"context"
+
 	"event-calendar/internal/domain"
 
 	"github.com/jmoiron/sqlx"

--- a/internal/service/user/user_account_service.go
+++ b/internal/service/user/user_account_service.go
@@ -2,10 +2,10 @@ package userservice
 
 import (
 	"context"
-
 	"event-calendar/internal/domain"
 	"event-calendar/internal/option"
 	"event-calendar/internal/repository"
+	"fmt"
 )
 
 type UserAccountService struct {
@@ -33,10 +33,7 @@ func (s UserAccountService) ListUserAccountsByUserID(
 
 	userAccounts, err = repo.ListUserAccountsByUserID(ctx, userID)
 	if err != nil {
-		//if errors.Is(err, repository.ErrNoRows) {
-		//return customError with status code NotFound
-		//}
-		return nil, err
+		return nil, fmt.Errorf("service.ListUserAccountsByUserID: %w", err)
 	}
 
 	return userAccounts, nil
@@ -64,7 +61,7 @@ func (s UserAccountService) CreateUserAccount(
 
 	userID, err := repo.CreateUserAccount(ctx, userAccount, ignoreConflicts)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("service.CreateUserAccount: %w", err)
 	}
 
 	return userID, nil

--- a/internal/service/user/user_account_service.go
+++ b/internal/service/user/user_account_service.go
@@ -2,10 +2,11 @@ package userservice
 
 import (
 	"context"
+	"fmt"
+
 	"event-calendar/internal/domain"
 	"event-calendar/internal/option"
 	"event-calendar/internal/repository"
-	"fmt"
 )
 
 type UserAccountService struct {

--- a/internal/service/user/user_profile_service.go
+++ b/internal/service/user/user_profile_service.go
@@ -2,10 +2,10 @@ package userservice
 
 import (
 	"context"
-
 	"event-calendar/internal/domain"
 	"event-calendar/internal/option"
 	"event-calendar/internal/repository"
+	"fmt"
 )
 
 type UserProfileService struct {
@@ -34,10 +34,7 @@ func (s UserProfileService) GetUserProfileByID(
 
 	userProfile, err = repo.GetUserProfileByID(ctx, ID)
 	if err != nil {
-		//if errors.Is(err, repository.ErrNoRows) {
-		//return customError with status code NotFound
-		//}
-		return domain.UserProfile{}, false, err
+		return domain.UserProfile{}, false, fmt.Errorf("service.GetUserProfileByID: %w", err)
 	}
 
 	return userProfile, true, nil
@@ -57,10 +54,7 @@ func (s UserProfileService) GetUserProfileByUserID(
 
 	userProfile, err = repo.GetUserProfileByUserID(ctx, userID)
 	if err != nil {
-		//if errors.Is(err, repository.ErrNoRows) {
-		//return customError with status code NotFound
-		//}
-		return domain.UserProfile{}, false, err
+		return domain.UserProfile{}, false, fmt.Errorf("service.GetUserProfileByUserID: %w", err)
 	}
 
 	return userProfile, true, nil
@@ -78,12 +72,9 @@ func (s UserProfileService) GetUserProfileByUUID(
 	// inject tx into repository
 	repo := option.ApplyTx(s.userProfileRepository, options)
 
-	userProfile, err = repo.GetUserProfileByFirebaseUID(ctx, uuid)
+	userProfile, err = repo.GetUserProfileByFirebaseUUID(ctx, uuid)
 	if err != nil {
-		//if errors.Is(err, repository.ErrNoRows) {
-		//return customError with status code NotFound
-		//}
-		return domain.UserProfile{}, false, err
+		return domain.UserProfile{}, false, fmt.Errorf("service.GetUserProfileByUUID: %w", err)
 	}
 
 	return userProfile, true, nil
@@ -101,10 +92,7 @@ func (s UserProfileService) CreateUserProfile(
 
 	userProfileID, err := repo.CreateUserProfile(ctx, userProfile)
 	if err != nil {
-		//if errors.Is(err, repository.ErrDuplicate) {
-		//return customError with status code BadRequest
-		//}
-		return 0, err
+		return 0, fmt.Errorf("service.CreateUserProfile: %w", err)
 	}
 
 	return userProfileID, nil

--- a/internal/service/user/user_profile_service.go
+++ b/internal/service/user/user_profile_service.go
@@ -2,10 +2,11 @@ package userservice
 
 import (
 	"context"
+	"fmt"
+
 	"event-calendar/internal/domain"
 	"event-calendar/internal/option"
 	"event-calendar/internal/repository"
-	"fmt"
 )
 
 type UserProfileService struct {

--- a/internal/service/user/user_service.go
+++ b/internal/service/user/user_service.go
@@ -2,10 +2,10 @@ package userservice
 
 import (
 	"context"
-
 	"event-calendar/internal/domain"
 	"event-calendar/internal/option"
 	"event-calendar/internal/repository"
+	"fmt"
 )
 
 type UserService struct {
@@ -34,10 +34,7 @@ func (s UserService) GetUserByID(
 
 	user, err := repo.GetUserByID(ctx, ID)
 	if err != nil {
-		//if errors.Is(err, repository.ErrNoRows) {
-		//return customError with status code NotFound
-		//}
-		return domain.User{}, false, err
+		return domain.User{}, false, fmt.Errorf("service.GetUserByID: %w", err)
 	}
 
 	return user, user.HasValidID(), nil
@@ -55,12 +52,9 @@ func (s UserService) GetUserByUUID(
 	// inject tx into repository
 	repo := option.ApplyTx(s.userRepository, options)
 
-	user, err := repo.GetUserByFirebaseUID(ctx, uuid)
+	user, err := repo.GetUserByFirebaseUUID(ctx, uuid)
 	if err != nil {
-		//if errors.Is(err, repository.ErrNoRows) {
-		//return customError with status code NotFound
-		//}
-		return domain.User{}, false, err
+		return domain.User{}, false, fmt.Errorf("service.GetUserByUUID: %w", err)
 	}
 
 	return user, user.HasValidID(), nil
@@ -78,10 +72,8 @@ func (s UserService) CreateUser(
 
 	userID, err := repo.CreateUser(ctx, user)
 	if err != nil {
-		//if errors.Is(err, repository.ErrDuplicate) {
-		//return customError with status code BadRequest
-		//}
-		return 0, err
+
+		return 0, fmt.Errorf("service.CreateUser: %w", err)
 	}
 
 	return userID, nil

--- a/internal/service/user/user_service.go
+++ b/internal/service/user/user_service.go
@@ -2,10 +2,11 @@ package userservice
 
 import (
 	"context"
+	"fmt"
+
 	"event-calendar/internal/domain"
 	"event-calendar/internal/option"
 	"event-calendar/internal/repository"
-	"fmt"
 )
 
 type UserService struct {


### PR DESCRIPTION
## Changes to codebase

### Improvements

#### Repository

Refused exposing database errors cause it's considered as violation of abstraction (database, db driver and thier errors are considered as implementation details). 

1. Refactor error handling in UserRepositoryPostgres
2. Refactor error handling in UserAccountRepositoryPostgres
3. Refactor error handling in UserProfileRepositoryPostgres

#### Service

Error Wrapping allows higher layers to inspect error chain (the sequence of errors produced by repeated unwrapping) and handle specific error types.

1. Wrap errors in UserService 
2. Wrap errors in UserAccountService
3. Wrap errors in UserProfileService

#### Other improvements

Improved Contextualization in Repository and Service layers:  Add context (e.g., including function names and parameters in error messages) makes it easier to identify the root cause during debugging and probably during logging.